### PR TITLE
style.css: Allow bold text

### DIFF
--- a/templates/style.scss
+++ b/templates/style.scss
@@ -37,10 +37,6 @@ html, button, input, select, textarea,
     color: $color-standard;
 }
 
-strong {
-    font-weight: 500;
-}
-
 .pure-button-normal {
     background-color: #fff;
     box-sizing: border-box !important;


### PR DESCRIPTION
This simply removes the default rule that made bold style invisible. Rustdoc pages must be able to use bold style.

Fixes #63 