### PR TITLE
Fix sass on recent releases name.

### DIFF
--- a/templates/style.scss
+++ b/templates/style.scss
@@ -210,6 +210,8 @@ div.recent-releases-container {
     .name {
         color: $color-url;
         font-weight: 500;
+        text-overflow: ellipsis;
+        overflow: hidden;
     }
 
     .build {


### PR DESCRIPTION
I realize that there's an issue if the crate name is too long.
Please let me know if you would like this done differently.

Before:
![img](https://cloud.githubusercontent.com/assets/4008156/20307708/96ca1e0a-ab38-11e6-95ca-4ba28390458c.png)

After:
![img_after](https://cloud.githubusercontent.com/assets/4008156/20307714/9d45ed54-ab38-11e6-84e6-1f68f979c2f9.png)

