### PR TITLE
apply playpen by default

### DIFF
--- a/src/utils/build_doc.rs
+++ b/src/utils/build_doc.rs
@@ -43,6 +43,8 @@ pub fn build_doc(name: &str, vers: Option<&str>, target: Option<&str>) -> CargoR
     let target_dir = PathBuf::from(current_dir)
         .join(format!("{}-{}", pkg.manifest().name(), pkg.manifest().version()));
 
+    let playpen_args = ["--playground-url".to_string(), "https://play.rust-lang.org/".to_string(),
+                        "-Zunstable-options".to_string()];
     let opts = ops::CompileOptions {
         config: &config,
         jobs: None,
@@ -56,7 +58,7 @@ pub fn build_doc(name: &str, vers: Option<&str>, target: Option<&str>) -> CargoR
         message_format: ops::MessageFormat::Human,
         filter: ops::CompileFilter::new(true, &[], &[], &[], &[]),
         target_rustc_args: None,
-        target_rustdoc_args: None,
+        target_rustdoc_args: Some(&playpen_args),
     };
 
     let ws = try!(Workspace::ephemeral(pkg, &config, Some(Filesystem::new(target_dir))));


### PR DESCRIPTION
The standard library API docs allow us running example code at https://play.rust-lang.org/ (which powered by playpen). But there're only very little amount of crates (i.g. [num](https://docs.rs/num/0.1.36/num/), [frunk](https://docs.rs/frunk/0.1.9/frunk/), [rusqbin](https://docs.rs/rusqbin/0.1.5/rusqbin/)) on crates.io have this feature. Most other crate authors don't know about `#![doc(html_playground_url = "https://play.rust-lang.org/")]`, or forget adding it to crate root.

Since rustdoc has `--playground-url` option (cc https://github.com/rust-lang/rust/pull/37763), it's time to apply playpen by default to all crates.io crates. For crates have their own `#![doc(html_playground_url = "URL")]`, nothing will be changed.