### PR TITLE
Add real-time PubSubHubBub to the feed

### DIFF
--- a/src/docbuilder/queue.rs
+++ b/src/docbuilder/queue.rs
@@ -35,8 +35,9 @@ impl DocBuilder {
 
 
     /// Builds packages from queue
-    pub fn build_packages_queue(&mut self) -> Result<()> {
+    pub fn build_packages_queue(&mut self) -> Result<usize> {
         let conn = try!(connect_db());
+        let mut build_count = 0;
 
         for row in &try!(conn.query("SELECT id, name, version
                                      FROM queue
@@ -49,6 +50,7 @@ impl DocBuilder {
 
             match self.build_package(&name[..], &version[..]) {
                 Ok(_) => {
+                    build_count += 1;
                     let _ = conn.execute("DELETE FROM queue WHERE id = $1", &[&id]);
                 }
                 Err(e) => {
@@ -63,7 +65,7 @@ impl DocBuilder {
             }
         }
 
-        Ok(())
+        Ok(build_count)
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,3 +12,4 @@ mod build_doc;
 mod copy;
 mod release_activity_updater;
 mod daemon;
+mod pubsubhubbub;

--- a/src/utils/pubsubhubbub.rs
+++ b/src/utils/pubsubhubbub.rs
@@ -1,0 +1,22 @@
+use std::collections::HashMap;
+
+use reqwest::*;
+
+fn ping_hub(url: &str) -> Result<Response> {
+    let mut params = HashMap::new();
+    params.insert("hub.mode", "publish");
+    params.insert("hub.url", "https://docs.rs/releases/feed");
+    let client = try!(Client::new());
+    client.post(url).form(&params).send()
+}
+
+/// Ping the two predefined hubs. Return either the number of successfully
+/// pinged hubs, or the first error.
+pub fn ping_hubs() -> Result<usize> {
+    vec!["https://pubsubhubbub.appspot.com",
+         "https://pubsubhubbub.superfeedr.com"]
+            .into_iter()
+            .map(ping_hub)
+            .collect::<Result<Vec<_>>>()
+            .map(|v| v.len())
+}

--- a/templates/releases_feed.hbs
+++ b/templates/releases_feed.hbs
@@ -4,6 +4,8 @@
 <subtitle>Recent Rust crates</subtitle>
 <link href="https://docs.rs/releases/feed" rel="self" />
 <link href="https://docs.rs/" />
+<link href="https://pubsubhubbub.appspot.com" rel="hub" />
+<link href="https://pubsubhubbub.superfeedr.com" rel="hub" />
 <id>urn:docs-rs:{{cratesfyi_version_safe}}</id>
 <updated>{{content[0].release_time_rfc3339}}</updated>
 {{#each content}}


### PR DESCRIPTION
[PubSubHubBub](https://en.wikipedia.org/wiki/PubSubHubbub) is a protocol that lets readers of an atom or RSS feed subscribe to a hub so that they get warned when the feed information has been updated.

The hub takes care of managing the subscription information, subscription refreshing, and so on. When it receives a "ping" from the web site, indicating that the feed has been updated, it checks it and contacts all subscribers with the new information (including the feed itself in some cases, a.k.a. fat ping).

To use the two major public hubs ([Google](https://pubsubhubbub.appspot.com/) and [SuperFeedr](https://pubsubhubbub.superfeedr.com/)), a site only needs to add two `<link rel="hub" href="…" />` lines to its feed, and ping the hubs through a `POST` request when the feed has been modified. Those two steps are implemented in the two commits of this PR.

As an example, people using the [SuperFeedr Telegram bot](https://telegram.me/superfeedr_bot) to get information on newly built documentation will get it as soon as it gets published instead of having the bot poll the docs.rs feed periodically.