### PR TITLE
Use our own version of rusttype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,12 +1131,18 @@ dependencies = [
 [[package]]
 name = "rusttype"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/onur/rusttype.git?rev=2c0b58a4017c1387b0bb621def92541eba256381#2c0b58a4017c1387b0bb621def92541eba256381"
 dependencies = [
  "arrayvec 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "stb_truetype 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rusttype"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+replace = "rusttype 0.2.1 (git+https://github.com/onur/rusttype.git?rev=2c0b58a4017c1387b0bb621def92541eba256381)"
 
 [[package]]
 name = "sass-rs"
@@ -1731,6 +1737,7 @@ dependencies = [
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
+"checksum rusttype 0.2.1 (git+https://github.com/onur/rusttype.git?rev=2c0b58a4017c1387b0bb621def92541eba256381)" = "<none>"
 "checksum rusttype 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c64ffc93b0cc5a6f5e5e84da2a4082b0271e0a1dd76e821bdac570bda7797e"
 "checksum sass-rs 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "98552ea76b181c4c6d490619e273649432dff0333b8278c53529a86bb99e1a6e"
 "checksum sass-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a243aaa2ca9f52b55fdf0ac6b169cbe3e98ec45b0180fced467d4d090f52c0e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ rev = "9fe7f07579d6d2672dd7e95c70adaea65d8e9a2e"
 version = "0.14"
 features = [ "with-time", "with-rustc-serialize" ]
 
+[replace."rusttype:0.2.1"]
+git = "https://github.com/onur/rusttype.git"
+rev = "2c0b58a4017c1387b0bb621def92541eba256381"
+
 [dev-dependencies]
 tempdir = "0.3"
 


### PR DESCRIPTION
Closes: #121 

This must fix nightly rusttype compilation problem but vagrant image needs to be tested.