### PR TITLE
Add crate details to rustdoc navigation

### DIFF
--- a/src/web/crate_details.rs
+++ b/src/web/crate_details.rs
@@ -45,6 +45,8 @@ pub struct CrateDetails {
     metadata: MetaData,
     is_library: bool,
     doc_targets: Option<Json>,
+    license: Option<String>,
+    documentation_url: Option<String>,
 }
 
 
@@ -81,6 +83,8 @@ impl ToJson for CrateDetails {
         m.insert("metadata".to_string(), self.metadata.to_json());
         m.insert("is_library".to_string(), self.is_library.to_json());
         m.insert("doc_targets".to_string(), self.doc_targets.to_json());
+        m.insert("license".to_string(), self.license.to_json());
+        m.insert("documentation_url".to_string(), self.documentation_url.to_json());
         m.to_json()
     }
 }
@@ -112,7 +116,9 @@ impl CrateDetails {
                             crates.github_forks,
                             crates.github_issues,
                             releases.is_library,
-                            releases.doc_targets
+                            releases.doc_targets,
+                            releases.license,
+                            releases.documentation_url
                      FROM releases
                      INNER JOIN crates ON releases.crate_id = crates.id
                      WHERE crates.name = $1 AND releases.version = $2;";
@@ -180,6 +186,8 @@ impl CrateDetails {
             metadata: metadata,
             is_library: rows.get(0).get(21),
             doc_targets: rows.get(0).get(22),
+            license: rows.get(0).get(23),
+            documentation_url: rows.get(0).get(24),
         };
 
         if let Some(repository_url) = crate_details.repository_url.clone() {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -324,15 +324,14 @@ fn render_markdown(text: &str) -> String {
 
 /// Returns latest version if required version is not the latest
 /// req_version must be an exact version
-fn latest_version(versions_json: &Json, req_version: &str) -> Option<String> {
+fn latest_version(versions_json: &Vec<String>, req_version: &str) -> Option<String> {
     let req_version = match Version::parse(req_version) {
         Ok(v) => v,
         Err(_) => return None,
     };
     let versions = {
         let mut versions: Vec<Version> = Vec::new();
-        for version in versions_json.as_array().unwrap() {
-            let version: String = version.as_string().unwrap().to_owned();
+        for version in versions_json {
             let version = match Version::parse(&version) {
                 Ok(v) => v,
                 Err(_) => return None,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -471,18 +471,13 @@ mod test {
 
     #[test]
     fn test_latest_version() {
-        let json = r#"
-        [
-            "1.0.0",
-            "1.1.0",
-            "0.9.0",
-            "0.9.1"
-        ]
-        "#;
-        let json = Json::from_str(json).unwrap();
-        assert_eq!(latest_version(&json, "1.1.0"), None);
-        assert_eq!(latest_version(&json, "1.0.0"), Some("1.1.0".to_owned()));
-        assert_eq!(latest_version(&json, "0.9.0"), Some("1.1.0".to_owned()));
-        assert_eq!(latest_version(&json, "invalidversion"), None);
+        let versions = vec!["1.0.0".to_string(),
+                            "1.1.0".to_string(),
+                            "0.9.0".to_string(),
+                            "0.9.1".to_string()];
+        assert_eq!(latest_version(&versions, "1.1.0"), None);
+        assert_eq!(latest_version(&versions, "1.0.0"), Some("1.1.0".to_owned()));
+        assert_eq!(latest_version(&versions, "0.9.0"), Some("1.1.0".to_owned()));
+        assert_eq!(latest_version(&versions, "invalidversion"), None);
     }
 }

--- a/templates/crate_details.hbs
+++ b/templates/crate_details.hbs
@@ -13,6 +13,7 @@
           {{/each}}
           <li class="pure-menu-heading">Links</li>
           {{#if homepage_url}}<li class="pure-menu-item"><a href="{{homepage_url}}" class="pure-menu-link"><i class="fa fa-home fa-fw"></i> Homepage</a></li>{{/if}}
+          {{#if documentation_url}}<li class="pure-menu-item"><a href="{{documentation_url}}" title="Canonical documentation" class="pure-menu-link"><i class="fa fa-fw fa-file-text"></i> Documentation</a></li>{{/if}}
           {{#if github}}
           <li class="pure-menu-item">
             <a href="{{repository_url}}" class="pure-menu-link"><i class="fa fa-github fa-fw"></i> <i class="fa fa-star-o fa-fw"></i> {{github_stars}} <i class="fa fa-code-fork fa-fw"></i> {{github_forks}} <i class="fa fa-exclamation-circle fa-fw"></i> {{github_issues}}</a>

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -12,71 +12,70 @@
               <a href="/crate/{{name}}/{{version}}" class="pure-menu-link" title="{{description}}"><i class="fa fa-fw fa-cube"></i><span class="title"> {{name}}-{{version}}</span></a>
               <div class="pure-menu-children package-details-menu">
                 <!-- CRATE DETAILS -->
-  <div class="pure-g menu-item-divided">
-    <div class="pure-u-1-2">
-        <ul class="pure-menu-list">
-          <li class="pure-menu-heading">Links</li>
-          {{#if homepage_url}}<li class="pure-menu-item"><a href="{{homepage_url}}" class="pure-menu-link"><i class="fa fa-home fa-fw"></i> Homepage</a></li>{{/if}}
-          {{#if github}}
-          <li class="pure-menu-item">
-            <a href="{{repository_url}}" class="pure-menu-link"><i class="fa fa-github fa-fw"></i> <i class="fa fa-star-o fa-fw"></i> {{github_stars}} <i class="fa fa-code-fork fa-fw"></i> {{github_forks}} <i class="fa fa-exclamation-circle fa-fw"></i> {{github_issues}}</a>
-          </li>
-          {{else}}
-          {{#if repository_url}}<li class="pure-menu-item"><a href="{{repository_url}}" class="pure-menu-link"><i class="fa fa-code-fork fa-fw"></i> Repository</a></li>{{/if}}
-          {{/if}}
-          <li class="pure-menu-item"><a href="https://crates.io/crates/{{name}}" class="pure-menu-link" title="See {{name}} in crates.io"><i class="fa fa-cube fa-fw"></i> Crates.io</a></li>
-        </ul>
-    </div>
-
-    <div class="pure-u-1-2">
-        <ul class="pure-menu-list">
-          <li class="pure-menu-heading">Authors</li>
-          {{#each authors}}
-          <li class="pure-menu-item"><a href="/releases/{{this.[1]}}" class="pure-menu-link">{{this.[0]}}</a></li>
-          {{/each}}
-        </ul>
-    </div>
-  </div>
-
-  <div class="pure-g">
-    <div class="pure-u-1-2">
-
-        <ul class="pure-menu-list">
-          <li class="pure-menu-heading">Dependencies</li>
-          <li class="pure-menu-item">
-            <div class="pure-menu pure-menu-scrollable sub-menu">
-              <ul class="pure-menu-list">
-                {{#each dependencies}}
-                <li class="pure-menu-item"><a href="/crate/{{this.[0]}}/{{this.[1]}}" class="pure-menu-link">{{this.[0]}} {{this.[1]}}</a></li>
-                {{/each}}
-              </ul>
-            </div>
-          </li>
-        </ul>
-    </div>
-    <div class="pure-u-1-2">
-
-        <ul class="pure-menu-list">
-          <li class="pure-menu-heading">Versions</li>
-          <li class="pure-menu-item">
-            <div class="pure-menu pure-menu-scrollable sub-menu">
-              <ul class="pure-menu-list">
-                {{#each versions}}
-                <li class="pure-menu-item"><a href="/crate/{{../name}}/{{this}}" class="pure-menu-link">{{this}}</a></li>
-                {{/each}}
-              </ul>
-            </div>
-          </li>
-        </ul>
-    </div>
-  </div>
-
-
-                <!-- / CRATE DETAILS -->
-
-
-
-
+                <ul class="pure-menu-list menu-item-divided">
+                  <li class="pure-menu-heading">{{name}}</li>
+                  <li class="pure-menu-item">
+                    <a href="/crate/{{name}}/{{version}}" class="pure-menu-link" class="description"><i class="fa fa-fw fa-cube"></i> {{description}}</a>
+                  </li>
+                  <li class="pure-menu-item">
+                    <a href="/crate/{{name}}/{{version}}" class="pure-menu-link"><i class="fa fa-fw fa-balance-scale"></i> {{license}}</a>
+                  </li>
+                </ul>
+                <div class="pure-g menu-item-divided">
+                  <div class="pure-u-1-2 right-border">
+                    <ul class="pure-menu-list">
+                      <li class="pure-menu-heading">Links</li>
+                      {{#if homepage_url}}<li class="pure-menu-item"><a href="{{homepage_url}}" class="pure-menu-link"><i class="fa fa-home fa-fw"></i> Homepage</a></li>{{/if}}
+                      {{#if documentation_url}}<li class="pure-menu-item"><a href="{{documentation_url}}" title="Canonical documentation" class="pure-menu-link"><i class="fa fa-fw fa-file-text"></i> Documentation</a></li>{{/if}}
+                      {{#if github}}
+                      <li class="pure-menu-item">
+                        <a href="{{repository_url}}" class="pure-menu-link"><i class="fa fa-github fa-fw"></i> <i class="fa fa-star-o fa-fw"></i> {{github_stars}} <i class="fa fa-code-fork fa-fw"></i> {{github_forks}} <i class="fa fa-exclamation-circle fa-fw"></i> {{github_issues}}</a>
+                      </li>
+                      {{else}}
+                      {{#if repository_url}}<li class="pure-menu-item"><a href="{{repository_url}}" class="pure-menu-link"><i class="fa fa-code-fork fa-fw"></i> Repository</a></li>{{/if}}
+                      {{/if}}
+                      <li class="pure-menu-item"><a href="https://crates.io/crates/{{name}}" class="pure-menu-link" title="See {{name}} in crates.io"><i class="fa fa-cube fa-fw"></i> Crates.io</a></li>
+                    </ul>
+                  </div>
+                  <div class="pure-u-1-2">
+                    <ul class="pure-menu-list">
+                      <li class="pure-menu-heading">Authors</li>
+                      {{#each authors}}
+                      <li class="pure-menu-item"><a href="/releases/{{this.[1]}}" class="pure-menu-link"><i class="fa fa-fw fa-user"></i> {{this.[0]}}</a></li>
+                      {{/each}}
+                    </ul>
+                  </div>
+                </div>
+                <div class="pure-g">
+                  <div class="pure-u-1-2 right-border">
+                    <ul class="pure-menu-list">
+                      <li class="pure-menu-heading">Dependencies</li>
+                      <li class="pure-menu-item">
+                        <div class="pure-menu pure-menu-scrollable sub-menu">
+                          <ul class="pure-menu-list">
+                            {{#each dependencies}}
+                            <li class="pure-menu-item"><a href="/crate/{{this.[0]}}/{{this.[1]}}" class="pure-menu-link">{{this.[0]}} {{this.[1]}}</a></li>
+                            {{/each}}
+                          </ul>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                  <div class="pure-u-1-2">
+                    <ul class="pure-menu-list">
+                      <li class="pure-menu-heading">Versions</li>
+                      <li class="pure-menu-item">
+                        <div class="pure-menu pure-menu-scrollable sub-menu">
+                          <ul class="pure-menu-list">
+                            {{#each versions}}
+                            <li class="pure-menu-item"><a href="/crate/{{../name}}/{{this}}" class="pure-menu-link">{{this}}</a></li>
+                            {{/each}}
+                          </ul>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
               </div>
             </li>
             {{#unless ../../varsb.is_latest_version}}

--- a/templates/navigation_rustdoc.hbs
+++ b/templates/navigation_rustdoc.hbs
@@ -6,10 +6,78 @@
             <input class="search-input-nav" name="query" tabindex="-1" type="text" placeholder="Find crate"{{#if varss.search_query}} value="{{varss.search_query}}"{{/if}}>
             {{/unless}}
             <a href="/" class="pure-menu-heading pure-menu-link"><i class="fa fa-cubes fa-fw"></i><span class="title"> Docs.rs</span></a>
-          {{#with content.metadata}}
+          {{#with content.crate_details}}
           <ul class="pure-menu-list">
-            <li class="pure-menu-item">
+            <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
               <a href="/crate/{{name}}/{{version}}" class="pure-menu-link" title="{{description}}"><i class="fa fa-fw fa-cube"></i><span class="title"> {{name}}-{{version}}</span></a>
+              <div class="pure-menu-children package-details-menu">
+                <!-- CRATE DETAILS -->
+  <div class="pure-g menu-item-divided">
+    <div class="pure-u-1-2">
+        <ul class="pure-menu-list">
+          <li class="pure-menu-heading">Links</li>
+          {{#if homepage_url}}<li class="pure-menu-item"><a href="{{homepage_url}}" class="pure-menu-link"><i class="fa fa-home fa-fw"></i> Homepage</a></li>{{/if}}
+          {{#if github}}
+          <li class="pure-menu-item">
+            <a href="{{repository_url}}" class="pure-menu-link"><i class="fa fa-github fa-fw"></i> <i class="fa fa-star-o fa-fw"></i> {{github_stars}} <i class="fa fa-code-fork fa-fw"></i> {{github_forks}} <i class="fa fa-exclamation-circle fa-fw"></i> {{github_issues}}</a>
+          </li>
+          {{else}}
+          {{#if repository_url}}<li class="pure-menu-item"><a href="{{repository_url}}" class="pure-menu-link"><i class="fa fa-code-fork fa-fw"></i> Repository</a></li>{{/if}}
+          {{/if}}
+          <li class="pure-menu-item"><a href="https://crates.io/crates/{{name}}" class="pure-menu-link" title="See {{name}} in crates.io"><i class="fa fa-cube fa-fw"></i> Crates.io</a></li>
+        </ul>
+    </div>
+
+    <div class="pure-u-1-2">
+        <ul class="pure-menu-list">
+          <li class="pure-menu-heading">Authors</li>
+          {{#each authors}}
+          <li class="pure-menu-item"><a href="/releases/{{this.[1]}}" class="pure-menu-link">{{this.[0]}}</a></li>
+          {{/each}}
+        </ul>
+    </div>
+  </div>
+
+  <div class="pure-g">
+    <div class="pure-u-1-2">
+
+        <ul class="pure-menu-list">
+          <li class="pure-menu-heading">Dependencies</li>
+          <li class="pure-menu-item">
+            <div class="pure-menu pure-menu-scrollable sub-menu">
+              <ul class="pure-menu-list">
+                {{#each dependencies}}
+                <li class="pure-menu-item"><a href="/crate/{{this.[0]}}/{{this.[1]}}" class="pure-menu-link">{{this.[0]}} {{this.[1]}}</a></li>
+                {{/each}}
+              </ul>
+            </div>
+          </li>
+        </ul>
+    </div>
+    <div class="pure-u-1-2">
+
+        <ul class="pure-menu-list">
+          <li class="pure-menu-heading">Versions</li>
+          <li class="pure-menu-item">
+            <div class="pure-menu pure-menu-scrollable sub-menu">
+              <ul class="pure-menu-list">
+                {{#each versions}}
+                <li class="pure-menu-item"><a href="/crate/{{../name}}/{{this}}" class="pure-menu-link">{{this}}</a></li>
+                {{/each}}
+              </ul>
+            </div>
+          </li>
+        </ul>
+    </div>
+  </div>
+
+
+                <!-- / CRATE DETAILS -->
+
+
+
+
+              </div>
             </li>
             {{#unless ../../varsb.is_latest_version}}
             <li class="pure-menu-item">
@@ -19,15 +87,15 @@
             <li class="pure-menu-item">
               <a href="/crate/{{name}}/{{version}}/source/" title="Browse source of {{name}}-{{version}}" class="pure-menu-link{{#if ../../varsb.package_source_tab}} pure-menu-active{{/if}}"><i class="fa fa-fw fa-folder-open-o"></i><span class="title"> Source</span></a>
             </li>
-          {{/with}}
             <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
               <a href="#" class="pure-menu-link"><i class="fa fa-fw fa-gears"></i><span class="title"> Platform</span></a>
               <ul class="pure-menu-children">
-                {{#each content.platforms}}
+                {{#each doc_targets}}
                 <li class="pure-menu-item"><a href="/{{../../metadata.name}}/{{../../metadata.version}}/{{this}}/{{../../metadata.target_name}}/" class="pure-menu-link">{{this}}</a></li>
                 {{/each}}
               </ul>
             </li>
+          {{/with}}
           </ul>
           </form>
         </div>

--- a/templates/rustdoc.hbs
+++ b/templates/rustdoc.hbs
@@ -3,6 +3,7 @@
   <head>
     {{{content.rustdoc_head}}}
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/menus-min.css" type="text/css" media="all" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-min.css" type="text/css" media="all" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css" type="text/css" media="all" />
     <link rel="stylesheet" href="/style.css?{{cratesfyi_version_safe}}" type="text/css" media="all" />
     <link rel="search" href="https://docs.rs/opensearch.xml" type="application/opensearchdescription+xml" title="Docs.rs">

--- a/templates/style.scss
+++ b/templates/style.scss
@@ -175,8 +175,25 @@ div.nav-container {
         div.package-details-menu {
             width: 350px;
 
+            p.description {
+                font-family: $font-family-sans;
+                font-size: 0.8em;
+                color: #777;  // color from pure
+                padding: .5em 1em;
+                margin: 0;
+            }
+
             ul.pure-menu-list {
                 width: 100%;
+            }
+
+            div.right-border {
+                border-right: 1px solid $color-border;
+            }
+            
+            a.pure-menu-link {
+                word-wrap: normal;
+                white-space: normal;
             }
 
             div.sub-menu {

--- a/templates/style.scss
+++ b/templates/style.scss
@@ -171,6 +171,27 @@ div.nav-container {
                 display: inline;
             }
         }
+
+        div.package-details-menu {
+            width: 350px;
+
+            ul.pure-menu-list {
+                width: 100%;
+            }
+
+            div.sub-menu {
+                max-height: 150px;
+                overflow-y: auto;
+
+                ul.pure-menu-list {
+                    border-top: none;
+                }
+
+                li.pure-menu-item:last-child {
+                    border-bottom: none;
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
* [x] Show crate description and license info as well.
* [ ] License link is not pointing to anywhere useful, fix it.
* [ ] Navigation height is causing some problems on Chrome for some reason, fix it.

Overview:

![new-nav](https://cloud.githubusercontent.com/assets/345828/26489351/b3deae20-420f-11e7-8a8e-09acd2eba7e2.png)
