### PR TITLE
Change `Github` to `GitHub`

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -14,7 +14,7 @@
 
   <p>
   The source code of Docs.rs is available on
-    <a href="https://github.com/onur/docs.rs" target="_blank">Github</a>. If
+    <a href="https://github.com/onur/docs.rs" target="_blank">GitHub</a>. If
   you ever encounter an issue, don't hesitate to report it! (And
   thanks in advance!)
   </p>


### PR DESCRIPTION
That's how it's officially spelled.