### PR TITLE
Fix error when compiling rusttype

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
     ############################################################
     lxc-attach -n cratesfyi-container -- apt-get update
     lxc-attach -n cratesfyi-container -- apt-get install -y --no-install-recommends curl ca-certificates binutils gcc libc6-dev libmagic1
-    lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2017-05-21'
+    lxc-attach -n cratesfyi-container -- su - cratesfyi -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-03-25'
 
     ############################################################
     # Creating rustc links for cratesfyi user                  #


### PR DESCRIPTION
I got the following error with compiling *rusttype* when I did `vagrant up` after a fresh checkout

```bash
    default: error[E0277]: the trait bound `std::sync::Arc<[u8]>: std::convert::From<std::boxed::Box<[u8]>>` is not satisfied
    default:    --> /home/cratesfyi/.cargo/registry/src/github.com-1ecc6299db9ec823/rusttype-0.4.0/src/lib.rs:146:34
    default:     |
    default: 146 |         SharedBytes::ByArc(bytes.into())
    default:     |                                  ^^^^ the trait `std::convert::From<std::boxed::Box<[u8]>>` is not implemented for `std::sync::Arc<[u8]>`
    default:     |
    default:     = help: the following implementations were found:
    default:               <std::sync::Arc<T> as std::convert::From<T>>
    default:     = note: required because of the requirements on the impl of `std::convert::Into<std::sync::Arc<[u8]>>` for `std::boxed::Box<[u8]>`
    default: error[E0277]: the trait bound `std::sync::Arc<[u8]>: std::convert::From<std::vec::Vec<u8>>` is not satisfied
    default:    --> /home/cratesfyi/.cargo/registry/src/github.com-1ecc6299db9ec823/rusttype-0.4.0/src/lib.rs:151:34
    default:     |
    default: 151 |         SharedBytes::ByArc(bytes.into())
    default:     |                                  ^^^^ the trait `std::convert::From<std::vec::Vec<u8>>` is not implemented for `std::sync::Arc<[u8]>`
    default:     |
    default:     = help: the following implementations were found:
    default:               <std::sync::Arc<T> as std::convert::From<T>>
    default:     = note: required because of the requirements on the impl of `std::convert::Into<std::sync::Arc<[u8]>>` for `std::vec::Vec<u8>`
    default: error
    default: : aborting due to 2 previous errors
    default: error: Could not compile `rusttype`.
    default: Build failed, waiting for other jobs to finish...
```

This seems very similar to https://github.com/redox-os/rusttype/issues/71. Updating the nightly version used by vagrant fixed the issue for me. I see that the latest travis build on master uses `rustc 1.24.1 (d3ae9a9e0 2018-02-27)`, which could explain why build didn't fail.