### PR TITLE
Document docs.rs metadata on the 'about' page.

### DIFF
--- a/templates/about.hbs
+++ b/templates/about.hbs
@@ -99,6 +99,24 @@
     </tbody>
   </table>
 
+  <h4>Metadata for custom builds</h4>
+
+  <p>You can customize docs.rs builds by defining <code>[package.metadata.docs.rs]</code> table in your crates' `Cargo.toml`.</p>
+
+  <p>An example metadata:</p>
+
+  <pre><code>[package]
+  name = "test"
+
+  [package.metadata.docs.rs]
+  features = [ "feature1", "feature2" ]
+  all-features = true
+  no-default-features = true
+  default-target = "x86_64-unknown-linux-gnu"
+  rustc-args = [ "--example-rustc-arg" ]
+  rustdoc-args = [ "--example-rustdoc-arg" ]
+  dependencies = [ "example-system-dependency" ]</pre></code>
+
   <h4>Version</h4>
   <p>Currently running Docs.rs version is: <strong>{{cratesfyi_version}}</strong>
 


### PR DESCRIPTION
Someone online asked me what this metadata section was in one of my Cargo.toml files, and it'd be helpful if this documentation was somewhere on the docs.rs site.

Docs/example taken from:

* https://github.com/onur/docs.rs/blob/8a31bf722cb416fec86866e3dd54ba59762e31fa/src/docbuilder/metadata.rs#L15-L27