### PR TITLE
move the built `cratesfyi` into the vagrant container

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,6 +65,7 @@ CRATESFYI_DATABASE_URL=postgresql://cratesfyi@localhost
 CRATESFYI_GITHUB_USERNAME=
 CRATESFYI_GITHUB_ACCESSTOKEN=
 RUST_LOG=cratesfyi
+CARGO_TARGET_DIR=/home/cratesfyi/docs.rs/target
 EOF
 
     ############################################################
@@ -105,7 +106,7 @@ EOF
     ############################################################
     # Copying docs.rs into container                           #
     ############################################################
-    cp -v /vagrant/target/debug/cratesfyi /var/lib/lxc/cratesfyi-container/rootfs/usr/local/bin
+    cp -v /home/cratesfyi/docs.rs/target/debug/cratesfyi /var/lib/lxc/cratesfyi-container/rootfs/usr/local/bin
 
     ############################################################
     # Re-creating database                                     #


### PR DESCRIPTION
Works around https://github.com/rust-lang/rust/issues/49710 when developing docs.rs with a Windows host.

This sets the `CARGO_TARGET_DIR` environment variable within the vagrant box to a folder inside the container rather than in the share. This means that when building the `cratesfyi` executable or the docs.rs service, the files will be placed inside the container (in `/home/cratesfyi/target`) rather than in `/vagrant`. This does mean that the binaries will be unavailable outside the container without manually copying them out. However, without this change, any build will fail with an error like the one in the linked issue. Combined with https://github.com/onur/docs.rs/pull/216, I can fully build docs.rs from a Windows host.